### PR TITLE
Fix typo in SvgIcon

### DIFF
--- a/template/src/common/SvgIcon/index.js
+++ b/template/src/common/SvgIcon/index.js
@@ -1,5 +1,5 @@
 const SvgIcon = ({ src, width, height }) => (
-  <img src={`/img/svg/${src}`} alt={src} with={width} height={height} />
+  <img src={`/img/svg/${src}`} alt={src} width={width} height={height} />
 );
 
 export default SvgIcon;


### PR DESCRIPTION
`width` was misspelled as `with`, causing issues when dropping in different SVGs for the ones used in the template.