### PR TITLE
Update translation.json

### DIFF
--- a/template/src/locales/en/translation.json
+++ b/template/src/locales/en/translation.json
@@ -21,8 +21,5 @@
   "Submit": "Submit",
   "Message" : "Message",
   "Your Message": "Your Message",
-  "Name" : "Message",
-  "Your Name": "Your Name",
-  "Email" : "Message",
-  "Your Email": "Your Message"
+  "Your Name": "Your Name"
 }


### PR DESCRIPTION
Removed a few lines that contained incorrect mappings which were causing the Contact Form to render with the wrong words.