### PR TITLE
Added missing Dependency for @ant-design/icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@ant-design/icons": "^4.8.3",
     "@types/node": "^15.14.9",
     "@types/react": "^17.0.68",
     "@types/react-dom": "^17.0.21",


### PR DESCRIPTION
This pull request addresses an issue where the **@ant-design/icons** package was missing from the **package.json** file, leading to the TypeScript error __TS2307: Cannot find module '@ant-design/icons' or its corresponding type declarations__. This error prevents the application from compiling successfully, as the MenuOutlined icon from **@ant-design/icons** is used in the **HeaderSection** component.